### PR TITLE
Small fix to the installation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ to simplify the process of getting up and running. If you like the YOLO
 approach of bootstrapping:
 
 ```
-curl -L https://github.com/thegedge/dotfiles/blob/master/install.sh | sh
+curl -L https://raw.githubusercontent.com/thegedge/dotfiles/master/install.sh | sh
 ```
 
 You can also download, verify, and manually run the script yourself, or pick


### PR DESCRIPTION
Github doesn't serve static files if unless we request from GitHub user content. Fixing that in the installation link.